### PR TITLE
Add SQLite config for development and test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,11 @@
+default: &default
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  timeout: 5000
+  database: <%= Rails.root.join("storage", "#{Rails.env}.sqlite3") %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default


### PR DESCRIPTION
## Summary
- add `config/database.yml` with default SQLite configuration

## Testing
- `bundle exec rake spec` *(fails: rbenv version `3.2.0` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c95da69a8832b855ee69d150e52ce