### PR TITLE
Add JSON serialization to models

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,7 @@
 
 class Event < ApplicationRecord
   include DefineGameNumberColumn
+  serialize :event_data, JSON
 
   EVENT_TYPES = %w[game_started card_exchanged game_ended invalid_command_event].freeze
 

--- a/app/models/query/history.rb
+++ b/app/models/query/history.rb
@@ -2,6 +2,7 @@ module Query
   class History < ApplicationRecord
     include DefineLastEventIdColumn
     include DefineGameNumberColumn
+    serialize :hand_set, JSON
     validates :hand_set, presence: true
     validates :rank, presence: true
     validates :ended_at, presence: true

--- a/app/models/query/player_hand_state.rb
+++ b/app/models/query/player_hand_state.rb
@@ -3,6 +3,7 @@ module Query
     include DefineCurrentTurnColumn
     include DefineLastEventIdColumn
     include DefineGameNumberColumn
+    serialize :hand_set, JSON
 
     enum :status, { initial: 0, started: 1, ended: 2 }
 

--- a/app/models/query/trash_state.rb
+++ b/app/models/query/trash_state.rb
@@ -3,6 +3,7 @@ module Query
     include DefineCurrentTurnColumn
     include DefineLastEventIdColumn
     include DefineGameNumberColumn
+    serialize :discarded_cards, JSON
 
     validate :validate_discarded_cards_format
 


### PR DESCRIPTION
## Summary
- enable serialization for event and query models to store JSON

## Testing
- `bundle exec rspec` *(fails: Could not load database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685c9833ac44832b894ac68e8332a228